### PR TITLE
Fix e2e error

### DIFF
--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -4,7 +4,7 @@ import { runTests } from "@vscode/test-electron";
 
 async function main() {
   try {
-    const extensionDevelopmentPath = path.resolve(__dirname, "../../../");
+    const extensionDevelopmentPath = path.resolve(__dirname, "../../"); // __dirname is out/test, so ../../ points to out
     const extensionTestsPath = path.resolve(__dirname, "./index");
 
     await runTests({ extensionDevelopmentPath, extensionTestsPath });


### PR DESCRIPTION
The e2e tests were failing with "Error: Extension 'oshikiri.generic-annotator' not found."
This was caused by an incorrect `extensionDevelopmentPath` in `src/test/runTest.ts`.
The `extensionDevelopmentPath` was pointing to the project root, but it should point to the `out` directory where the compiled extension resides.

By changing `extensionDevelopmentPath` from `../../../` to `../../`, the `@vscode/test-electron` runner can now correctly find and load the extension, allowing the e2e tests to pass.

***
The path, once lost, now clearly seen,
Extension's home, where it has been.
Development's journey, now complete,
With tests that pass, a victory sweet.
***
